### PR TITLE
Fix get_member_by_id not found error.

### DIFF
--- a/ro_py/groups.py
+++ b/ro_py/groups.py
@@ -259,7 +259,7 @@ class Group(ClientObject):
         # Find group in list.
         group_data = None
         for group in data['data']:
-            if group['group']['id'] == self.id:
+            if group['group']['id'] == int(self.id):
                 group_data = group
                 break
 


### PR DESCRIPTION
Before, `get_member_by_id` would error with a `NotFound` since it was trying to compare a string and an int. This just adds an int() to convert the group id to an int, which is what the response is.