### PR TITLE
Allow clearing shout by passing None to groups.Shout

### DIFF
--- a/ro_py/groups.py
+++ b/ro_py/groups.py
@@ -61,8 +61,8 @@ class Shout:
         """
         shout_req = await self.requests.patch(
             url=endpoint + f"/v1/groups/{self.group.id}/status",
-            data={
-                "message": message
+            json={
+                "message": message or ""
             }
         )
         self.group.shout = Shout(self.cso, self.group, shout_req.json())


### PR DESCRIPTION
Making the request data JSON lets us clear the shout by passing `""` or `None` to group.shout(), which would make clearing shouts easier.